### PR TITLE
Use nodejs v16 in CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,6 +12,6 @@ jobs:
           key: npm-${{ hashFiles('**/package-lock.json') }}
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: 12
+          node-version: 16
       - run: npm install
       - run: npm run prettier:check


### PR DESCRIPTION
nodejs v16 also comes with npm v7

[skip netlify]