### PR TITLE
Improve accessibility of code snippets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,7 +15,9 @@ module.exports = (config) => {
       linkify: false,
     }).use(markdownItFootnote)
   );
-  config.addPlugin(require('@11ty/eleventy-plugin-syntaxhighlight'));
+  config.addPlugin(require('@11ty/eleventy-plugin-syntaxhighlight'), {
+    preAttributes: { tabindex: 0 },
+  });
   config.addPassthroughCopy('src/site/robots.txt');
   config.addWatchTarget('src/utils');
 


### PR DESCRIPTION
‘@11ty/eleventy-plugin-syntaxhighlight’ recently [added][1] support for
preAttributes that can be used to put a tabindex attributes on a
scrollable (`overflow: auto;`) `<pre>` element. It's not yet the default
setting for these elements, but this sets it through the eleventy
config.

[1]: https://github.com/11ty/eleventy-plugin-syntaxhighlight/pull/48