### PR TITLE
Add link to dependabot options

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
 updates:
   - package-ecosystem: "npm"


### PR DESCRIPTION
Add a link to the dependabot configuration options to `.dependabot.yml`
for future reference.