### PR TITLE
build: explicitly set packageManager 

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.2
       - uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 9
       - uses: actions/setup-node@v4.0.2
         with:
           node-version-file: .node-version

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "npm-run-all": "4.1.5",
     "postcss": "8.4.38",
     "postcss-cli": "11.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.0.4+sha256.caa915eaae9d9aefccf50ee8aeda25a2f8684d8f9d5c6e367eaf176d97c1f89e"
 }


### PR DESCRIPTION
- In package.json, set "packageManager" explicitly.
- In .github/workflows/nodejs-ci.yml remove the version of pnpm to install as it will automatically use the version in package.json