### PR TITLE
build: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -8,7 +7,11 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
-    open-pull-requests-limit: 10
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- Remove comment
- Use groups for production and development to reduce the number of pull requests that are opened