### PR TITLE
build: version actions using hashes

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -5,9 +5,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
-      - uses: pnpm/action-setup@v4.0.0
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version-file: .node-version
           cache: pnpm


### PR DESCRIPTION
Because tags can be removed and added again, use hashes for the versions of actions instead of tags.