### PR TITLE
test: remove packageManager field

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 9.3.0
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .node-version

--- a/package.json
+++ b/package.json
@@ -32,6 +32,5 @@
     "postcss": "8.4.38",
     "postcss-cli": "11.0.0",
     "rimraf": "5.0.7"
-  },
-  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
+  }
 }


### PR DESCRIPTION
To test if Dependabot corrupts `pnpm-lock.yaml`, remove "packageManager" temporarily.