### PR TITLE
build: prettier config

### DIFF
--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -4,9 +4,7 @@ import prettierPluginXML from '@prettier/plugin-xml';
  * @type {import("prettier").Config}
  **/
 export default {
-  proseWrap: 'always',
   singleQuote: true,
-  trailingComma: 'all',
   overrides: [
     {
       files: ['*.css', '*.scss', '*.yml'],
@@ -18,6 +16,12 @@ export default {
       files: ['*.svg'],
       options: {
         plugins: [prettierPluginXML],
+      },
+    },
+    {
+      files: '*.md',
+      options: {
+        proseWrap: 'always',
       },
     },
   ],


### PR DESCRIPTION
- Remove `trailingComma: 'all'`, it is the default now
- Move `proseWrap` into its own override for just Markdown files where it belongs