### PR TITLE
build: keep @types/node in line with node LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # keep @types/node in line with the current LTS node version
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "probablerobot-net",
   "private": true,
+  "type": "module",
   "scripts": {
     "clean": "rimraf public",
     "start": "npm-run-all clean --parallel start:*",
@@ -15,10 +16,11 @@
     "lint:fix": "eslint --fix",
     "knip": "knip"
   },
+  "packageManager": "pnpm@9.12.2",
   "devDependencies": {
     "@eslint/js": "9.12.0",
     "@prettier/plugin-xml": "3.4.1",
-    "@types/node": "22.7.5",
+    "@types/node": "20.16.13",
     "eslint": "9.12.0",
     "eslint-plugin-perfectionist": "3.8.0",
     "globals": "15.11.0",
@@ -37,7 +39,5 @@
     "postcss": "8.4.47",
     "postcss-cli": "11.0.0",
     "rimraf": "6.0.1"
-  },
-  "packageManager": "pnpm@9.12.1",
-  "type": "module"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: 3.4.1
         version: 3.4.1(prettier@3.3.3)
       '@types/node':
-        specifier: 22.7.5
-        version: 22.7.5
+        specifier: 20.16.13
+        version: 20.16.13
       eslint:
         specifier: 9.12.0
         version: 9.12.0(jiti@2.3.3)
@@ -59,7 +59,7 @@ importers:
         version: 15.11.0
       knip:
         specifier: 5.33.3
-        version: 5.33.3(@types/node@22.7.5)(typescript@5.6.3)
+        version: 5.33.3(@types/node@20.16.13)(typescript@5.6.3)
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -209,8 +209,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@22.7.5':
-    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+  '@types/node@20.16.13':
+    resolution: {integrity: sha512-GjQ7im10B0labo8ZGXDGROUl9k0BNyDgzfGpb4g/cl+4yYDWVKcozANF4FGr4/p0O/rAkQClM6Wiwkije++1Tg==}
 
   '@typescript-eslint/scope-manager@8.8.1':
     resolution: {integrity: sha512-X4JdU+66Mazev/J0gfXlcC/dV6JI37h+93W9BRYXrSn0hrE64IoWgVkO9MSJgEzoWkxONgaQpICWg8vAN74wlA==}
@@ -2289,7 +2289,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@22.7.5':
+  '@types/node@20.16.13':
     dependencies:
       undici-types: 6.19.8
 
@@ -3297,11 +3297,11 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knip@5.33.3(@types/node@22.7.5)(typescript@5.6.3):
+  knip@5.33.3(@types/node@20.16.13)(typescript@5.6.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@snyk/github-codeowners': 1.1.0
-      '@types/node': 22.7.5
+      '@types/node': 20.16.13
       easy-table: 1.2.0
       enhanced-resolve: 5.17.1
       fast-glob: 3.3.2


### PR DESCRIPTION
Make sure that Dependabot does not update the major version of `@types/node` to a version of node beyond the LTS version of node.