### PR TITLE
chore: ignore scripts during pnpm install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
-save-prefix=
+ignore-scripts=true
 save-exact=true
+save-prefix=


### PR DESCRIPTION
Experiment with `ignore-scripts` in `.npmrc`