### PR TITLE
chore: update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,3 @@ updates:
       day: 'saturday'
       time: '00:00'
       timezone: 'Etc/UTC'
-  - package-ecosystem: 'docker'
-    directory: '/.devcontainer/'
-    schedule:
-      interval: 'weekly'
-      day: 'saturday'
-      time: '00:00'
-      timezone: 'Etc/UTC'


### PR DESCRIPTION
Remove the Docker package ecosystem as it's no longer used