### PR TITLE
chore: rewrite workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 permissions:
   contents: read
 
-on: pull_request
+on:
+  pull_request:
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
Use the expanded form of `on: pull_request` because it is more in line with GitHub's documentation.