### PR TITLE
chore: pnpm/dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: 'saturday'
       time: '00:00'
       timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 5
     groups:
       # group all patch and minor version updates in one pull request
       minor-dependencies:
@@ -26,3 +28,5 @@ updates:
       day: 'saturday'
       time: '00:00'
       timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+minimumReleaseAge: 7200
+
 saveExact: true
+
 savePrefix: ''


### PR DESCRIPTION
Add cooldowns for pnpm and Dependabot.

- Set pnpm's minimumReleaseAge to 7200 minutes (5 days)
- Set Dependabot's cooldown.default-days to 5 days